### PR TITLE
Fix login redirection and splash screen navigation

### DIFF
--- a/lib/screen/connexion/components/body.dart
+++ b/lib/screen/connexion/components/body.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:share_file_iai/screen/home_screen/home_screen.dart';
 import 'package:share_file_iai/screen/inscription/InscriptionScreen.dart';
 import 'package:share_file_iai/screen/inscription/components/email_input.dart';
 import 'package:share_file_iai/screen/inscription/components/psd_input.dart';
@@ -42,7 +43,14 @@ class _BodyState extends State<Body> {
         if (!mounted) return;
         ScaffoldMessenger.of(context)
             .showSnackBar(const SnackBar(content: Text('Connexion reussite')));
-
+        Navigator.pushReplacement(
+          context,
+          MaterialPageRoute(
+            builder: (context) => HomeScreen(
+              user: _auth.currentUser!,
+            ),
+          ),
+        );
         // La redirection est maintenant gérée par le StreamBuilder dans main.dart
       } on FirebaseAuthException catch (e) {
         if (!mounted) return;

--- a/lib/screen/spalshscreen/components/body.dart
+++ b/lib/screen/spalshscreen/components/body.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:share_file_iai/screen/connexion/connexion_screnn.dart';
 import 'package:share_file_iai/screen/inscription/InscriptionScreen.dart';
 import 'package:share_file_iai/widget/bouton_continuer.dart';
 
@@ -69,7 +70,7 @@ class _BodyState extends State<Body> {
               BoutonContinuer(
                 size: size,
                 press: () {
-                  Navigator.pushReplacementNamed(context, InscriptionScreen.routeName);
+                  Navigator.pushReplacementNamed(context, ConnexionScreen.routeName);
                 },
               ),
               const SizedBox(height: 50),


### PR DESCRIPTION
This commit addresses two issues:
1.  You were not redirected to the home screen after a successful login. I fixed this by adding an explicit navigation to the HomeScreen after the `signInWithEmailAndPassword` call.
2.  The splash screen was navigating to the sign-up screen instead of the login screen. I fixed this by changing the route in the splash screen's "Continue" button to point to the ConnexionScreen.