### PR TITLE
feat: redirect to login screen after logout

### DIFF
--- a/lib/screen/AccountSettings/accout_setting_page.dart
+++ b/lib/screen/AccountSettings/accout_setting_page.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:share_file_iai/screen/connexion/connexion_screnn.dart';
 
 class AccountSettingsPage extends StatefulWidget {
   @override
@@ -71,6 +72,12 @@ class _AccountSettingsPageState extends State<AccountSettingsPage> {
 
   Future<void> _signOut() async {
     await FirebaseAuth.instance.signOut();
+    if (!mounted) return;
+    Navigator.pushNamedAndRemoveUntil(
+      context,
+      ConnexionScreen.routeName,
+      (route) => false,
+    );
   }
 
   @override


### PR DESCRIPTION
The logout button in the settings page was not redirecting you to the login screen after a successful logout.

This change fixes the issue by adding a navigation call to the `_signOut` method in `lib/screen/AccountSettings/accout_setting_page.dart`. After signing out, you are now redirected to the `ConnexionScreen`.